### PR TITLE
feat: enable non-Org file types

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((emacs-lisp-mode . ((indent-tabs-mode . nil))))

--- a/citar-denote.el
+++ b/citar-denote.el
@@ -57,11 +57,11 @@
 
 (defconst citar-denote-config
   (list :name "Denote"
-	:category 'file
-	:items #'citar-denote-get-notes
-	:hasitems #'citar-denote-has-notes
-	:open #'find-file
-	:create #'citar-denote-create-note)
+        :category 'file
+        :items #'citar-denote-get-notes
+        :hasitems #'citar-denote-has-notes
+        :open #'find-file
+        :create #'citar-denote-create-note)
   "Instructing citar to use citar-denote functions.")
 
 (defvar citar-notes-source)
@@ -78,14 +78,14 @@
 
 (defun citar-denote-create-note (key &optional entry)
   "Create a bibliography note for `KEY' with properties `ENTRY'."
-  (let ((denote-file-type denote-file-type)) 
+  (let ((denote-file-type denote-file-type))
     (denote
      (read-string "Title: " (citar-get-value "title" key))
      (citar-denote-keywords-prompt))
     (with-current-buffer (current-buffer)
       (goto-char (point-min))
       (while (not(eq (char-after) 10))
-	(next-line))
+        (next-line))
       (insert (format "#+reference:  %s" key))
       (newline)
       (newline))))
@@ -98,26 +98,26 @@ If `KEYS' is omitted, return notes for all Denote files tagged with
   (let ((files (make-hash-table :test 'equal)))
     (prog1 files
       (dolist (file (denote-directory-files-matching-regexp
-		     (concat "_" citar-denote-keyword)))
-	(with-current-buffer (find-file-noselect file)
-	  (save-excursion
-	    (beginning-of-buffer)
-	    (when (search-forward "#+reference:" nil t)
-	      (forward-to-word 1)
-	      (setq marker1 (point))
-	      (end-of-line)
-	      (setq marker2 (point))
-	      (if keys
-		  (dolist (key keys)
-		    (when (string= key
-				   (buffer-substring-no-properties
-				    marker1 marker2))
-		      (push file (gethash key files))))
-		(let ((key (buffer-substring-no-properties marker1 marker2)))
-		  (push file (gethash key files))))))))
+                     (concat "_" citar-denote-keyword)))
+        (with-current-buffer (find-file-noselect file)
+          (save-excursion
+            (beginning-of-buffer)
+            (when (search-forward "#+reference:" nil t)
+              (forward-to-word 1)
+              (setq marker1 (point))
+              (end-of-line)
+              (setq marker2 (point))
+              (if keys
+                  (dolist (key keys)
+                    (when (string= key
+                                   (buffer-substring-no-properties
+                                    marker1 marker2))
+                      (push file (gethash key files))))
+                (let ((key (buffer-substring-no-properties marker1 marker2)))
+                  (push file (gethash key files))))))))
       (maphash (lambda (key filelist)
                  (puthash key (nreverse filelist) files))
-	       files))))
+               files))))
 
 (defun citar-denote-has-notes ()
   "Return predicate testing whether entry has associated denote files.

--- a/citar-denote.el
+++ b/citar-denote.el
@@ -51,6 +51,28 @@
   :group 'citar-denote
   :type '(repeat string))
 
+;; New variables to enable non-Org file types.  These are candidates for
+;; defcustom.
+(defvar citar-denote-file-type denote-file-type
+  "File Type used by Citar-Denote.
+Default is `denote-file-type'.  Users can use another file type
+for their bibliographic notes.")
+
+(defvar citar-denote-reference-format "#+reference:  %s\n"
+  "Property added to bibliographic notes' front matter.
+The default assumes Org file type.  Users can define their own;
+e.g. for the markdown file type the following might be preferred.
+
+   \"reference: \%s\\n\"")
+(defvar citar-denote-reference-regexp "^#\\+reference\\s-*:"
+  "Regexp used to look for the citekey in a bibliographic notes.
+The default assumes Org file type.  This must correspond to
+`citar-denote-reference-format'.")
+
+(defvar citar-denote-files-regexp (concat "_" citar-denote-keyword)
+  "Regexp used to look for file names of bibliographic notes.
+The default assumes \"_bib\" tag is part of the file name.")
+
 (defconst citar-denote-orig-source
   citar-notes-source
   "Store the `citar-notes-source' value prior to enabling citar-denote.")
@@ -76,19 +98,43 @@
               (sort choice #'string-lessp)
             choice))))
 
-(defun citar-denote-create-note (key &optional entry)
-  "Create a bibliography note for `KEY' with properties `ENTRY'."
-  (let ((denote-file-type denote-file-type))
+(defun citar-denote-add-reference (key file-type)
+  "Add reference property with KEY in front matter of FILE-TYPE.
+Currently it is added after keywords property, thus it needs to
+present in the front matter."
+  (goto-char (point-min))
+  (when (re-search-forward (denote--keywords-key-regexp file-type) nil t 1)
+    (goto-char (line-beginning-position 2))
+    (insert (format citar-denote-reference-format key))))
+
+(defun citar-denote-create-note (key &optional _entry)
+  "Create a bibliography note for `KEY' with properties `ENTRY'.
+The file type for the note to be created is determined by user
+option `denote-file-type'."
+  (let ((denote-file-type citar-denote-file-type))
     (denote
+     ;;(citar-get-value "title" key)
      (read-string "Title: " (citar-get-value "title" key))
      (citar-denote-keywords-prompt))
+    ;; TODO: Check if with-current-buffer (current-buffer) is needed.
+    ;; Left as is because the original version had it -- it's probably
+    ;; redandunt.
     (with-current-buffer (current-buffer)
-      (goto-char (point-min))
-      (while (not(eq (char-after) 10))
-        (next-line))
-      (insert (format "#+reference:  %s" key))
-      (newline)
-      (newline))))
+      (citar-denote-add-reference key denote-file-type))))
+
+(defun citar-denote-retrieve-reference-key-value (file file-type)
+  "Return cite key value from FILE front matter per FILE-TYPE.
+This function assume title and reference values can be retrieved
+by the same function per file-type; hence, it callls
+`denote--title-value-reverse-function' instead of requiring cite
+key specific function."
+  (with-temp-buffer
+    (insert-file-contents file)
+    (goto-char (point-min))
+    (when (re-search-forward citar-denote-reference-regexp nil t 1)
+      ;; Reuse denote--title-value-reverse-function
+      (funcall (denote--title-value-reverse-function file-type)
+               (buffer-substring-no-properties (point) (line-end-position))))))
 
 (defun citar-denote-get-notes (&optional keys)
   "Return Denote files associated with the `KEYS' list.
@@ -98,23 +144,14 @@ If `KEYS' is omitted, return notes for all Denote files tagged with
   (let ((files (make-hash-table :test 'equal)))
     (prog1 files
       (dolist (file (denote-directory-files-matching-regexp
-                     (concat "_" citar-denote-keyword)))
-        (with-current-buffer (find-file-noselect file)
-          (save-excursion
-            (beginning-of-buffer)
-            (when (search-forward "#+reference:" nil t)
-              (forward-to-word 1)
-              (setq marker1 (point))
-              (end-of-line)
-              (setq marker2 (point))
-              (if keys
-                  (dolist (key keys)
-                    (when (string= key
-                                   (buffer-substring-no-properties
-                                    marker1 marker2))
-                      (push file (gethash key files))))
-                (let ((key (buffer-substring-no-properties marker1 marker2)))
-                  (push file (gethash key files))))))))
+                     citar-denote-files-regexp))
+        (let ((key-in-file (citar-denote-retrieve-reference-key-value
+                            file denote-file-type)))
+          (if keys (dolist (key keys)
+                     (when (string= key key-in-file)
+                       (push file (gethash key-in-file files))))
+            ;; If optional arg keys are not provided
+            (push file (gethash key-in-file files)))))
       (maphash (lambda (key filelist)
                  (puthash key (nreverse filelist) files))
                files))))


### PR DESCRIPTION
As discussed in the ML of denote (https://lists.sr.ht/~protesilaos/denote/%3C87edtkls6y.fsf%40prevos.net%3E)

Two commits:

- [style: disable indent-tab-mode to use only spaces & no tabs](https://github.com/pprevos/citar-denote/commit/e2e8440a5b500719fec7c845f34bb726802bbfab) is a suggestion. I see that currently a mixture of tabs and spaces are used for indentation. My suggestion is to add `.dir-local.el` and disable `indent-tabs-mode` -- Prot does this for denote repo, too. This way, you standardize the indentation to use only spaces.  

- The main part is the commit [feat: enable non-Org file types](https://github.com/pprevos/citar-denote/commit/0d9faba1df9066ec6f1ac75d7e7643bb36995b4c). I hope I have explained the changed in the commit message with sufficient detail. 

Two additional comments for sharing and discussion.

- I use the following settings for my purposes. This way, my reference is compatible with Org-roam and Md-roam (my markdown extension for Org-roam). 

   I set  `denote-file-type` to 'markdown-yaml so `citar-denote-file-type` is left as the default. I  also customize the way a single tag is added to the file name ("B" for "#bib").
```
(setq citar-denote-reference-format "roam_refs: %s\n")
(setq citar-denote-reference-regexp "^roam_refs\\s-*:")
(setq citar-denote-files-regexp "_B_")
```

- As noted in the commit message, I have changed the original logic of `char-after 10`. This might have been premature. I'll be happy to hear your opinion and revert to the original. My honest thought was that it was a little bit hard to understand what was intended with char-after 10 -- took me a while that this was meant to look for the first blank line in the buffer. I'd appreciate your thought on this.