### PR TITLE
fix: citar-denote-file-type

### DIFF
--- a/citar-denote.el
+++ b/citar-denote.el
@@ -53,10 +53,10 @@
 
 ;; New variables to enable non-Org file types.  These are candidates for
 ;; defcustom.
-(defvar citar-denote-file-type denote-file-type
+(defvar citar-denote-file-type (or denote-file-type 'org)
   "File Type used by Citar-Denote.
-Default is `denote-file-type'.  Users can use another file type
-for their bibliographic notes.")
+Default is `denote-file-type' or org if the former is nil.  Users
+can use another file type for their bibliographic notes.")
 
 (defvar citar-denote-reference-format "#+reference:  %s\n"
   "Property added to bibliographic notes' front matter.


### PR DESCRIPTION
It causes an error if nil. 

We might want to look at it more carefully to see if there is a better solution. For now, this should fix the error. 