### PR TITLE
refactor: add-reference function to look for blank line 

### DIFF
--- a/citar-denote.el
+++ b/citar-denote.el
@@ -122,7 +122,7 @@ The default assumes \"_bib\" tag is part of the file name.")
 
 (defun citar-denote-add-reference (key file-type)
   "Add reference property with KEY in front matter of FILE-TYPE.
-Currently it is added after keywords property, thus it needs to
+Currently it is added after keywords property, thus it must be
 present in the front matter."
   (goto-char (point-min))
   (when (re-search-forward (denote--keywords-key-regexp file-type) nil t 1)

--- a/citar-denote.el
+++ b/citar-denote.el
@@ -122,12 +122,16 @@ The default assumes \"_bib\" tag is part of the file name.")
 
 (defun citar-denote-add-reference (key file-type)
   "Add reference property with KEY in front matter of FILE-TYPE.
-Currently it is added after keywords property, thus it must be
-present in the front matter."
+It is added after the keywords property if it is present.  If
+not, it is added in the first blank line, which can be outside
+the front matter depending on FILE-TYPE."
   (goto-char (point-min))
-  (when (re-search-forward (denote--keywords-key-regexp file-type) nil t 1)
-    (goto-char (line-beginning-position 2))
-    (insert (format (citar-denote-reference-format citar-denote-file-type) key))))
+  (if (re-search-forward (denote--keywords-key-regexp file-type) nil t 1)
+      ;; find keywords property and move to the next line
+      (goto-char (line-beginning-position 2))
+    ;; if keywords property is not present, move to the first blank line
+    (while (not (eq (char-after) 10)) (forward-line)))
+  (insert (format (citar-denote-reference-format citar-denote-file-type) key)))
 
 (defun citar-denote-create-note (key &optional _entry)
   "Create a bibliography note for `KEY' with properties `ENTRY'.


### PR DESCRIPTION
'citar-denote-add-reference' now has fall-back logic to look for a blank
line when the keywords property is not present in the front matter (the
original logic with 'char-after').

Denote allows user configuration to not have keywords property in the
front matter.  citar-denote also allows for regexp to search for
bibliographic notes other than "_bib" -- e.g. it can be a sub-directory
omitting keywords entirely.