### PR TITLE
Avoid duplicate citar-denote-keyword in citar-denote-keywords-prompt

### DIFF
--- a/citar-denote.el
+++ b/citar-denote.el
@@ -126,11 +126,11 @@ Configurable with `citar-denote-keyword'.")
 
 (defun citar-denote-keywords-prompt ()
   "Prompt for one or more keywords and include `citar-denote-keyword'."
-  (let ((choice (append (list citar-denote-keyword)
-                        (denote--keywords-crm (denote-keywords)))))
-    (if denote-sort-keywords
-        (sort choice #'string-lessp)
-      choice)))
+  (let ((choice (denote--keywords-crm (denote-keywords))))
+    (denote-keywords-sort
+     (if (member citar-denote-keyword choice)
+         choice
+       (append (list citar-denote-keyword) choice)))))
 
 (defun citar-denote-add-reference (key file-type)
   "Add reference property with KEY in front matter of FILE-TYPE."


### PR DESCRIPTION
I just started maintaining my own BibTeX bibliography and will be using citar-denote with it.  While creating a new note with citar-denote, I typed in the "bib" keyword, thinking that I had to do this manually.  The result was a file name with duplicate "bib" keywords.

This change addresses that issue.  It also uses the standard 'denote-keywords-sort' function instead of doing its own check.  In practice, this is the same though it is easier to maintain citar-denote in case we ever make changes to denote-keywords-sort.