### PR TITLE
Fix error about absence of 'denote-sort-keywords'

### DIFF
--- a/citar-denote.el
+++ b/citar-denote.el
@@ -127,10 +127,11 @@ Configurable with `citar-denote-keyword'.")
 (defun citar-denote-keywords-prompt ()
   "Prompt for one or more keywords and include `citar-denote-keyword'."
   (let ((choice (denote--keywords-crm (denote-keywords))))
-    (denote-keywords-sort
-     (if (member citar-denote-keyword choice)
-         choice
-       (append (list citar-denote-keyword) choice)))))
+    (unless (member citar-denote-keyword choice)
+      (setq choice (append (list citar-denote-keyword) choice)))
+    (if denote-sort-keywords
+        (sort choice #'string-lessp)
+      choice)))
 
 (defun citar-denote-add-reference (key file-type)
   "Add reference property with KEY in front matter of FILE-TYPE."


### PR DESCRIPTION
That function is still part of the current development version of Denote.

Thanks to Peter Prevos for spotting the error and informing me about
it: <https://github.com/pprevos/citar-denote/pull/9#issuecomment-1347803258>.