### PR TITLE
Fix reference to void variable file-type

### DIFF
--- a/citar-denote.el
+++ b/citar-denote.el
@@ -396,6 +396,7 @@ When `citar-denote-subdir' is non-nil, prompt for a subdirectory."
 (defun citar-denote-remove-citekey ()
   (interactive)
   (if-let* ((file (buffer-file-name))
+            (file-type (denote-filetype-heuristics file))
 	    (citekeys (citar-denote-retrieve-references file))
 	    (selected (if (< (length citekeys) 2)
 			  (car citekeys)


### PR DESCRIPTION
in `citar-denote-remove-citekey` function.

---

Hi,

Thank for you `citar-denote`, it's been very useful to me.

> Side note: I expected this function to prompt me to remove the citation keys individually rather than remove them all at once as well as extract the value of `citar-denote-use-bib-keywords` from the filename.