### PR TITLE
Update citar-denote.org

### DIFF
--- a/citar-denote.org
+++ b/citar-denote.org
@@ -184,6 +184,8 @@ This package is available in MELPA. The example below includes all configurable 
   (use-package citar-denote
     :demand t ;; Ensure minor mode is loaded
     :after (:any citar denote)
+    :preface
+    (bind-key "C-c w n" #'citar-denote-open-note)
     :custom
     ;; Allow multiple notes per bibliographic entry
     (citar-open-always-create-notes nil)
@@ -200,8 +202,7 @@ This package is available in MELPA. The example below includes all configurable 
     :config
     (citar-denote-mode)
     ;; Bind all available commands
-    :bind (("C-c w n" . citar-denote-open-note)
-           ("C-c w d" . citar-denote-dwim)
+    :bind (("C-c w d" . citar-denote-dwim)
            ("C-c w e" . citar-denote-open-reference-entry)
            ("C-c w a" . citar-denote-add-citekey)
            ("C-c w k" . citar-denote-remove-citekey)

--- a/citar-denote.org
+++ b/citar-denote.org
@@ -166,7 +166,7 @@ The ~citar-denote-nocite~ function opens the Citar menu. It shows all items in y
 
 The ~citar-denote-cite-nocite~ function cites an unused bibliographic entry. This function only works when the active buffer is a Denote Org mode note.
 
-Lastly, the ~citar-denote-no-bibliography~ function lists all references and citations in your Denote collection that are absent in the global bibliography in the =*Messages*= buffer. Note that this list excludes any local bibliographies. The output of this function is a list of citation keys used in Denote that need to be added or corrected.
+Lastly, the ~citar-denote-nobib~ function lists all references and citations in your Denote collection that are absent in the global bibliography in the =*Messages*= buffer. Note that this list excludes any local bibliographies. The output of this function is a list of citation keys used in Denote that need to be added or corrected.
 
 The citations search mechanism uses the =xref= system. You can improve the search process by installing the faster [[https://github.com/BurntSushi/ripgrep][ripgrep]] program and setting ~xref-search-program~ to =ripgrep=.
 
@@ -205,7 +205,6 @@ This package is available in MELPA. The example below includes all configurable 
            ("C-c w e" . citar-denote-open-reference-entry)
            ("C-c w a" . citar-denote-add-citekey)
            ("C-c w k" . citar-denote-remove-citekey)
-           ("C-c w n" . citar-denote-no-bibliography)
            ("C-c w r" . citar-denote-find-reference)
            ("C-c w l" . citar-denote-link-reference)
            ("C-c w f" . citar-denote-find-citation)


### PR DESCRIPTION
- Fix `citar-denote-no-bibliography`, which was renamed to `citar-denote-nobib` in 35c3a2f.
- Update example to ensure `citar-denote-open-note` is callable even when `citar-denote` is not loaded. (Please see commits description for details.) Functions such as `citar-denote-open-note` that may be called before either of denote or citar has been used can be bind in this way.

### Screencast
https://github.com/pprevos/citar-denote/assets/1143191/cc8e9359-6cc1-424c-94d4-238a5f4ebfb2

### Loading message in the message buffer
The message is based on config: https://git.sr.ht/~goofansu/emacs-config/tree/main/modules/init-denote.el#L97-115

```
exec-path-from-shell is loaded
envrc is loaded
vertico is loaded
vertico-multiform is loaded
marginalia is loaded
orderless is loaded
embark is loaded
corfu is loaded
cape is loaded
winner is loaded
shackle is loaded
modus-themes is loaded
spacious-padding is loaded
fontaine is loaded
pulsar is loaded
anzu is loaded
recentf is loaded
Loading /Users/james/.config/emacs/recentf...done
Cleaning up the recentf list...done (0 removed)
savehist is loaded
undo-fu is loaded
undo-fu-session is loaded
window is loaded
avy is loaded
tab-bar is loaded
frame is loaded
evil is loaded
evil-collection is loaded
evil-nerd-commenter is loaded
evil-snipe is loaded
evil-surround is loaded
evil-anzu is loaded
general is loaded
treesit is loaded
For information about GNU Emacs and the GNU system, type C-h C-a.
Emacs started in 0.832676 seconds
vertico-directory is loaded
project is loaded
denote is loaded
evil-org is loaded
org is loaded
restclient is loaded
ob-restclient is loaded
org-pandoc-import is loaded
oc is loaded
citar is loaded
citar-denote is loaded
Updating bibliography ~/src/notes/reference.bib...done (0.219 seconds)
sendmail is loaded
message is loaded
eww is loaded
git-gutter is loaded
smartparens is loaded
goggles is loaded
tempel is loaded
org-nix-shell is loaded
```
