### PR TITLE
introduce citar-denote-cite-includes-reference option

### DIFF
--- a/citar-denote.el
+++ b/citar-denote.el
@@ -138,6 +138,14 @@ For `author-year' and `author-year-title' you can configure:
   :group 'citar-denote
   :type  'string)
 
+(defcustom citar-denote-cite-includes-reference nil
+  "Include reference notes in cite search.
+When non-nil, searching for files citing a bibtex key will
+include Denote files that only contain the citekey in the
+reference front matter (and not as a @-style citation)."
+  :group 'citar-denote
+  :type  'boolean)
+
 (defvar citar-denote-file-types
   `((org
      :reference-format "#+reference:  %s\n"
@@ -248,13 +256,21 @@ If CITEKEYS is omitted, return all Denote files tagged with
          (puthash key (nreverse filelist) files)) files))))
 
 (defun citar-denote--retrieve-cite-files (citekey)
-  "Return names of Denote files that contain CITEKEY."
-  (let ((files (denote-directory-files nil nil t)))
+  "Return names of Denote files that contain CITEKEY.
+
+If `citar-denote-cite-includes-reference' is non-nil, the results
+will include Denote files with CITEKEY only in the reference
+front matter."
+  (let ((cite-sign (if citar-denote-cite-includes-reference "" "@"))
+                    ;; Include '@' in the xref query only when front
+                    ;; matter '#+reference:' to bibtex keyword should
+                    ;; not be included in the results
+        (files (denote-directory-files nil nil t)))
     (delete-dups
      (mapcar
       #'xref-location-group
       (mapcar #'xref-match-item-location
-              (xref-matches-in-files (format "@%s" citekey) files))))))
+              (xref-matches-in-files (format "%s%s" cite-sign citekey) files))))))
 
 (defun citar-denote--has-notes ()
   "Return a list of all citekeys referenced in a Denote file.


### PR DESCRIPTION
By default, citar-denote distinguishes references from citations. This means `citar-denote--retrieve-cite-files` does not return files that only contain the citekey in the frontmatter and do not cite the bibliographic entry in the text.

This commit introduces a custom variable to change this behaviour. When `citar-denote-cite-includes-reference` is non-nil, retrieving cited files will include files that only contain the citekey in the front matter.

The effect is achieved by not including the '@' sign in the xref query (when the option is non-nil).